### PR TITLE
feat: bump charts

### DIFF
--- a/azure/templates/deploy-datahub.yaml
+++ b/azure/templates/deploy-datahub.yaml
@@ -22,7 +22,7 @@ jobs:
                 command: upgrade
                 chartType: Name
                 chartName: datahub/datahub
-                chartVersion: 0.6.0
+                chartVersion: 0.6.15
                 releaseName: datahub
                 valueFile: helm/values.yaml
                 namespace: $(kubernetesNamespace)
@@ -41,7 +41,7 @@ jobs:
                 command: upgrade
                 chartType: Name
                 chartName: datahub/datahub
-                chartVersion: 0.6.0
+                chartVersion: 0.6.15
                 releaseName: datahub
                 valueFile: helm/values.yaml
                 namespace: $(kubernetesNamespace)

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -764,7 +764,7 @@ global:
       #   value: password
 
   datahub:
-    version: v1.0.0
+    version: v1.2.0
     gms:
       protocol: "http"
       port: "8080"


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

This PR bumps the charts of `datahub-prerequisites` and `datahub`

This also manually specifies to use datahub version 1.2.0 which contains the fixes for the graphQL feature