### PR TITLE
[GIGA-032] feat: enable graphql metrics

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -776,6 +776,20 @@ global:
       port: "8080"
       nodePort: "30001"
 
+      env:
+      - name: GRAPHQL_METRICS_ENABLED
+        value: "true"
+      - name: GRAPHQL_METRICS_FIELD_LEVEL_ENABLED
+        value: "true"
+      - name: GRAPHQL_METRICS_FIELD_LEVEL_OPERATIONS
+        value: ""
+      - name: GRAPHQL_METRICS_FIELD_LEVEL_PATH_ENABLED
+        value: "true"
+      - name: GRAPHQL_QUERY_INTROSPECTION_ENABLED
+        value: "true"
+      - name: GRAPHQL_METRICS_TRIVIAL_DATA_FETCHERS_ENABLED
+        value: "true"
+
     # Used for scheduled tasks
     timezone: "UTC"
 


### PR DESCRIPTION
## What type of PR is this?

- `feat`: Commits that add a new feature


## Summary

Enables environment variables that activate [GraphQL metrics](https://docs.datahub.com/docs/advanced/monitoring#integration-with-monitoring-stack) exposed in `datahub-gms` `prometheus/actuator` endpoint to allow prometheus metrics to scrape information related to GraphQL query preformance