### PR TITLE
fix: add path.repo configuration for snapshot support

### DIFF
--- a/helm/datahub-prerequisites/charts/elasticsearch/values.yaml
+++ b/helm/datahub-prerequisites/charts/elasticsearch/values.yaml
@@ -24,10 +24,9 @@ clusterDeprecationIndexing: "false"
 
 # Allows you to add any config files in /usr/share/elasticsearch/config/
 # such as elasticsearch.yml and log4j2.properties
-esConfig: {}
-#  elasticsearch.yml: |
-#    key:
-#      nestedkey: value
+esConfig:
+  elasticsearch.yml: |
+    path.repo: ["/tmp/giga"]
 #  log4j2.properties: |
 #    key = value
 


### PR DESCRIPTION
## What type of PR is this?
- `fix`: Commits that fix a bug

## Summary
This PR adds `path.repo` configuration to Elasticsearch to enable filesystem-based snapshot repositories for backups.